### PR TITLE
Refactor widgets and fix typos

### DIFF
--- a/lib/answer_button.dart
+++ b/lib/answer_button.dart
@@ -2,14 +2,14 @@ import 'package:flutter/material.dart';
 
 class AnswerButton extends StatelessWidget {
   // AnswerButton(this.answerText, this.answerAction, {super.key});
-  AnswerButton({
+  const AnswerButton({
     super.key,
     required this.answerText,
     required this.answerAction,
   });
 
   final String answerText;
-  void Function() answerAction;
+  final void Function() answerAction;
 
   @override
   Widget build(BuildContext context) {
@@ -31,6 +31,5 @@ class AnswerButton extends StatelessWidget {
         textAlign: TextAlign.center,
       ),
     );
-    ;
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,6 +3,6 @@ import 'package:adv_basics/quiz.dart';
 
 void main() {
   runApp(
-    Quiz(),
+    const Quiz(),
   );
 }

--- a/lib/models/quiz_question.dart
+++ b/lib/models/quiz_question.dart
@@ -5,9 +5,9 @@ class QuizQuestion {
   final String text;
   final List<String> answers;
 
-  List<String> getSheffledAnswers() {
-    final sheffledList = List.of(answers);
-    sheffledList.shuffle();
-    return  sheffledList;
+  List<String> getShuffledAnswers() {
+    final shuffledList = List.of(answers);
+    shuffledList.shuffle();
+    return shuffledList;
   }
 }

--- a/lib/questions_screen.dart
+++ b/lib/questions_screen.dart
@@ -48,7 +48,7 @@ class _QuestionScreenState extends State<QuestionsScreen> {
               textAlign: TextAlign.center,
             ),
             SizedBox(height: 30),
-            ...currentQuestion.getSheffledAnswers().map((answer) {
+            ...currentQuestion.getShuffledAnswers().map((answer) {
               return AnswerButton(
                   answerText: answer,
                   answerAction: () {

--- a/lib/questions_summary.dart
+++ b/lib/questions_summary.dart
@@ -1,9 +1,9 @@
 import 'package:flutter/material.dart';
 
-class QuestionsSammary extends StatelessWidget {
-  const QuestionsSammary(this.summaruData, {super.key});
+class QuestionsSummary extends StatelessWidget {
+  const QuestionsSummary(this.summaryData, {super.key});
 
-  final List<Map<String, Object>> summaruData;
+  final List<Map<String, Object>> summaryData;
 
   @override
   Widget build(BuildContext context) {
@@ -11,7 +11,7 @@ class QuestionsSammary extends StatelessWidget {
       height: 300,
       child: SingleChildScrollView(
         child: Column(
-          children: summaruData.map((data) {
+          children: summaryData.map((data) {
             return Row(
               children: [
                 Text(((data['question_index'] as int) + 1).toString()),

--- a/lib/result_screen.dart
+++ b/lib/result_screen.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:adv_basics/data/questions.dart';
-import 'package:adv_basics/questions_sammary.dart';
+import 'package:adv_basics/questions_summary.dart';
 
 class ResultScreen extends StatelessWidget {
   const ResultScreen({
@@ -43,7 +43,7 @@ class ResultScreen extends StatelessWidget {
             Text(
                 'You answered $numCorrectQuestions out of $numTotalQuestions questions correctly!'),
             SizedBox(height: 30),
-            QuestionsSammary(
+            QuestionsSummary(
               summaryData,
             ),
             SizedBox(height: 30),
@@ -55,6 +55,5 @@ class ResultScreen extends StatelessWidget {
         ),
       ),
     );
-    ;
   }
 }

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -8,23 +8,14 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import 'package:adv_basics/main.dart';
+import 'package:adv_basics/quiz.dart';
 
 void main() {
-  testWidgets('Counter increments smoke test', (WidgetTester tester) async {
+  testWidgets('Start screen shows start quiz button', (WidgetTester tester) async {
     // Build our app and trigger a frame.
-    await tester.pumpWidget(const MyApp());
+    await tester.pumpWidget(const Quiz());
 
-    // Verify that our counter starts at 0.
-    expect(find.text('0'), findsOneWidget);
-    expect(find.text('1'), findsNothing);
-
-    // Tap the '+' icon and trigger a frame.
-    await tester.tap(find.byIcon(Icons.add));
-    await tester.pump();
-
-    // Verify that our counter has incremented.
-    expect(find.text('0'), findsNothing);
-    expect(find.text('1'), findsOneWidget);
+    // Verify that the start button is present.
+    expect(find.text('Start Quiz'), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Summary
- fix typos in QuestionsSummary widget
- clean up AnswerButton widget
- expose `getShuffledAnswers` API
- update ResultScreen to use QuestionsSummary
- adjust main and widget test

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687135e6eec08321b807bbd0584dc554